### PR TITLE
FIX: Declaration of method must be compatible with parent

### DIFF
--- a/core/boxes/box_absence.php
+++ b/core/boxes/box_absence.php
@@ -116,9 +116,17 @@ class box_absence extends ModeleBoxes {
 		
 	}
 
-	function showBox($head = null, $contents = null)
+	/**
+	 * Method to show a box (usage by boxes not mandatory, a box can still use its own showBox function)
+	 *
+	 * @param   array   $head       Array with properties of box title
+	 * @param   array   $contents   Array with properties of box lines
+	 * @param	int		$nooutput	No print, only return string
+	 * @return  string
+	 */
+	function showBox($head = null, $contents = null, $nooutput=0)
 	{
-		parent::showBox($this->info_box_head, $this->info_box_contents);
+		parent::showBox($this->info_box_head, $this->info_box_contents, $nooutput);
 	}
 
 }


### PR DESCRIPTION
Avoid « Warning: Declaration of box_absence::showBox($head = NULL, $contents = NULL) should be compatible with ModeleBoxes::showBox($head = NULL, $contents = NULL, $nooutput = 0) in /var/www/dolibarr/htdocs/rh/absence/core/boxes/box_absence.php on line 0 »