### PR TITLE
FIX: timetable: rewrite pop-in to enable error messages

### DIFF
--- a/absence.php
+++ b/absence.php
@@ -23,83 +23,27 @@
 				break;
 
 			case 'save':
-				//$PDOdb->db->debug=true;
-				$absence->load($PDOdb, $_REQUEST['id']);
-				$absence->set_values($_REQUEST);
+			    $absenceSaved = saveAbsence($PDOdb, $absence);
 
-				$absence->set_date('date_debut', GETPOST('date_debutday').'/'.GETPOST('date_debutmonth').'/'.GETPOST('date_debutyear') );
-				$absence->set_date('date_fin', GETPOST('date_finday').'/'.GETPOST('date_finmonth').'/'.GETPOST('date_finyear') );
+			    $mode = 'edit';
 
-				$absence->niveauValidation=1;
-				$existeDeja=$absence->testExisteDeja($PDOdb, $absence);
-				if($existeDeja===false){
-					$absence->code=saveCodeTypeAbsence($PDOdb, $absence->type);
+			    if($absenceSaved)
+                {
+                    $mode = 'view';
+                    setEventMessage($langs->trans('RegistedRequest'));
 
-					// Test de la cohérence des dates
-					if(!$user->rights->absence->myactions->creerAbsenceCollaborateur && !TRH_valideur_groupe::isValideur($PDOdb, $user->id)
-					&& !$user->rights->absence->myactions->declarePastAbsence
-					&& ($absence->date_debut <= strtotime('midnight') ||$absence->date_fin <= strtotime('midnight') )) {
+                    if(! empty($absence->avertissementInfo))
+                    {
+                        setEventMessage($absence->avertissementInfo, 'warnings');
+                    }
+                }
+			    else
+                {
+                    setEventMessage($absence->error, 'errors');
+                }
 
-						//Ok le mec n'a pas le droit de créer une absence dans le passé mais est-ce qu'il peut le jour même
-						if ($user->rights->absence->myactions->declareToDayAbsence && $absence->date_debut >= strtotime('midnight') && $absence->date_fin >= strtotime('midnight'))
-						{
-							//RAS il peut créer l'absence le jour même
-						}
-						else
-						{
-							/*
-								Si ce n'est pas un user avec droit, pas le droit de créer des anciennes absences
-							*/
-							$mesg = '<div class="error">' . $langs->trans('ErrOnlyUserWithPowerCanCreatePastAbsence') . '</div>';
-							_fiche($PDOdb, $absence,'edit');
-							break;
-						}
-
-
-					}
-
-					if($absence->save($PDOdb)) {
-
-							if($absence->avertissementInfo) setEventMessage($absence->avertissementInfo, 'warnings');
-
-							$absence->load($PDOdb, $_REQUEST['id']);
-
-                            // Submit file
-                            $TPieceJointe = array();
-                            if(! empty($_FILES['userfile']['name'])) $TPieceJointe = $_FILES['userfile']['name'];
-			    if( count($_FILES['userfile']['name']) == 1 && empty($_FILES['userfile']['name'][0])) unset($_FILES['userfile']['name']); //Quand l'input est vide $_FILES n'est pas vide ce qui crée une erreur
-                            $res = dol_add_file_process($conf->absence->dir_output.'/'.dol_sanitizeFileName($absence->rowid), 0, 1, 'userfile', '');
-
-							if(GETPOST('autoValidatedAbsence')>0) {
-								$absence->setAcceptee($PDOdb, $user->id, false, $TPieceJointe);
-							}
-							else if($absence->fk_user==$user->id){	//on vérifie si l'absence a été créée par l'user avant d'envoyer un mail
-								mailConges($absence, false, $TPieceJointe);
-								mailCongesValideur($PDOdb,$absence, false, $TPieceJointe);
-							}
-
-
-							$mesg = $langs->trans('RegistedRequest');
-
-							_fiche($PDOdb, $absence,'view');
-					}
-					else{
-						$errors='';
-						foreach($absence->errors as $err) $errors.=$err.'<br />';
-
-						$mesg = $errors;
-						setEventMessage($mesg);
-
-						_fiche($PDOdb, $absence,'edit');
-
-					}
-
-
-				}else{
-					$popinExisteDeja = '<div class="error">' . $langs->trans('ImpossibleCreation') . ' : ' . $langs->trans('ErrExistingRequestInPeriod', date('d/m/Y', strtotime($existeDeja[0])), date('d/m/Y',  strtotime($existeDeja[1]))) . '</div>';
-					_fiche($PDOdb, $absence,'edit');
-				}
-				break;
+			    _fiche($PDOdb, $absence, $mode);
+                break;
 
 			case 'view':
 				if($absence->load($PDOdb, $_REQUEST['id'])) {

--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -755,23 +755,22 @@ class TRH_Absence extends TObjetStd {
 	}
 
 
-	function save(&$PDOdb, $runTrigger = true) {
-
-		global $conf, $user,$db,$langs;
+	function save(&$PDOdb, $runTrigger = true)
+	{
+		global $conf, $user, $db, $langs;
 		$this->entity = $conf->entity;
 
-		if(empty($this->code) || empty($this->libelle)) {
-
+		if(empty($this->code) || empty($this->libelle))
+		{
 			$ta = new TRH_TypeAbsence;
 			$ta->load_by_type($PDOdb, $this->type);
 
-			$this->code=$ta->codeAbsence;
-			$this->libelle=$ta->libelleAbsence;
-
+			$this->code = $ta->codeAbsence;
+			$this->libelle = $ta->libelleAbsence;
 		}
 
 		// Appel des triggers
-		dol_include_once('/core/class/interfaces.class.php');
+		require_once DOL_DOCUMENT_ROOT . '/core/class/interfaces.class.php';
 		$interface = new Interfaces($db);
 
 		$f_mode = $this->getId() > 0 ? 'UPDATE' : 'CREATE';
@@ -788,7 +787,7 @@ class TRH_Absence extends TObjetStd {
 
 		if($saveReturn > 0 && $runTrigger)
 		{
-			$result = $interface->run_triggers('ABSENCE_'.$f_mode,$this,$user,$langs,$conf);
+			$result = $interface->run_triggers('ABSENCE_' . $f_mode, $this, $user, $langs, $conf);
 		}
 
 		return $saveReturn;

--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -774,29 +774,24 @@ class TRH_Absence extends TObjetStd {
 		dol_include_once('/core/class/interfaces.class.php');
 		$interface = new Interfaces($db);
 
-		if($this->getId()>0) {
-			$result = $interface->run_triggers('ABSENCE_BEFOREUPDATE',$this,$user,$langs,$conf);
-			$f_mode = 'UPDATE';
-		}
-		else{
-			$result = $interface->run_triggers('ABSENCE_BEFORECREATE',$this,$user,$langs,$conf);
-			$f_mode = 'CREATE';
-		}
+		$f_mode = $this->getId() > 0 ? 'UPDATE' : 'CREATE';
 
-		if ($result < 0) {
-			$error++; $this->errors=$interface->errors;
+		$result = $interface->run_triggers('ABSENCE_BEFORE' . $f_mode, $this, $user, $langs, $conf);
+
+		if ($result < 0)
+		{
+			$this->errors = $interface->errors;
 			return false;
 		}
-		// Fin appel triggers
-		else {
-			parent::save($PDOdb);
 
-			if($runTrigger) $result = $interface->run_triggers('ABSENCE_'.$f_mode,$this,$user,$langs,$conf);
+		$saveReturn = parent::save($PDOdb);
 
-			return true;
+		if($saveReturn > 0 && $runTrigger)
+		{
+			$result = $interface->run_triggers('ABSENCE_'.$f_mode,$this,$user,$langs,$conf);
 		}
 
-
+		return $saveReturn;
 	}
 
 	

--- a/planningUser.php
+++ b/planningUser.php
@@ -22,7 +22,7 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
 	$date_fin=strtotime( date('Y-m-t') );
 	$idGroupeRecherche=$idGroupeRecherche2=$idGroupeRecherche3=0;
 	$idUserRecherche = (GETPOST('mode')=='auto') ? $user->id : 0;
-	
+
 	if(!isset($_GET['actionSearch'])) {
 		
 		if(!empty($_COOKIE['TRHPlanning']) ){
@@ -36,7 +36,7 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
 				$date_debut=$_COOKIE['TRHPlanning']['date_debut_search'];
 				$date_debut_time= str_replace('/', '-', $date_debut);
 				$date_debut_time=strtotime($date_debut_time);
-				$date_debut_time_1_month = strtotime("+1 month", $date_debut_time);
+				$date_debut_time_1_month = strtotime("+1 month -1 day", $date_debut_time);
 				$date_debut_recherche = $date_debut;
 			}
 

--- a/planningUser.php
+++ b/planningUser.php
@@ -314,12 +314,12 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
                             {
                                 $.jnotify(data.TMessages.warning, 'warning');
                             }
+
+                            refreshPlanning();
                         }
                     });
 
                     $("#popAbsence").dialog('close');
-
-                    refreshPlanning();
 
                     return false;
                 });

--- a/planningUser.php
+++ b/planningUser.php
@@ -283,32 +283,56 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
 	function popAddAbsence(date, fk_user) {
 		$('#popAbsence').remove();
 		$('body').append('<div id="popAbsence"></div>');
-		
-		var url = "<?php echo dol_buildpath('/absence/absence.php?action=new',1) ?>&dfMoment=apresmidi&ddMoment=matin&fk_user="+fk_user+"&date_debut="+date+"&date_fin="+date+"&popin=1 #fiche-abs";
-		
-		$('#popAbsence').load(url, function() {
-			$('#popAbsence form').submit(function() {
-				$.post($(this).attr('action'), $(this).serialize())
-					.done(function(data) {
-						$.jnotify('<?php echo $langs->trans('AbsenceAdded') ?>', "ok");
-					});
-			
-				$("#popAbsence").dialog('close');
-				
-				refreshPlanning();
 
-				return false;
-		
-			});
+		var url = "<?php echo dol_buildpath('/absence/absence.php?action=new',1) ?>&dfMoment=apresmidi&ddMoment=matin&fk_user="+fk_user+"&date_debut="+date+"&date_fin="+date+"&popin=1";
+        var selector = "#fiche-abs>#form1";
 
-		});
-		
-		
-		$('#popAbsence').dialog({
-			title:"Créer une nouvelle absence ou présence" /* TODO langs */
-			,width:500
-			,modal:true
-		});
+		$.ajax({
+            url: url
+            , method: 'GET'
+            , success: function(data)
+            {
+                $(data).find(selector).first().appendTo('#popAbsence');
+
+                $('#popAbsence form').submit(function() {
+                    $.ajax({
+                        url: "<?php echo dol_escape_js(dol_buildpath('/absence/script/interface.php', 1)) ?>?post=saveAbsence&inc=main"
+                        , method: 'POST'
+                        , data: $(this).serialize()
+                        , success : function (data)
+                        {
+                            if(data.saved)
+                            {
+                                $.jnotify(data.TMessages.ok, 'ok');
+                            }
+                            else
+                            {
+                                $.jnotify(data.TMessages.error, 'error');
+                            }
+
+                            if(data.TMessages.warning)
+                            {
+                                $.jnotify(data.TMessages.warning, 'warning');
+                            }
+                        }
+                    });
+
+                    $("#popAbsence").dialog('close');
+
+                    refreshPlanning();
+
+                    return false;
+                });
+
+                $('#popAbsence').dialog(
+                {
+                    title:"Créer une nouvelle absence ou présence"
+                    , width:'700'
+                    , position: { my: "center", at: "center center+40", of: window }
+                    , modal:true
+                });
+            }
+        });
 	}	
 
 	</script>

--- a/planningUser.php
+++ b/planningUser.php
@@ -303,6 +303,8 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
                         {
                             if(data.saved)
                             {
+                                refreshPlanning();
+                                $("#popAbsence").dialog('close');
                                 $.jnotify(data.TMessages.ok, 'ok');
                             }
                             else
@@ -314,12 +316,9 @@ function _planningResult(&$ATMdb, &$absence, $mode) {
                             {
                                 $.jnotify(data.TMessages.warning, 'warning');
                             }
-
-                            refreshPlanning();
                         }
                     });
 
-                    $("#popAbsence").dialog('close');
 
                     return false;
                 });


### PR DESCRIPTION
La pop-in de création d'absence se basait sur un `jQuery.load()` vers `absence.php`, ce qui avait deux inconvénients :
+ impossible de récupérer les messages d'erreur
+ les `<script>` n'étaient pas éxécutés (calendriers jQuery inopérants, par exemple).

L'appel au formulaire a été converti en appel ajax, son `submit` a été redirigé vers `script/interface.php` et le traitement de ces requêtes a été factorisé dans `lib/absence.lib.php`

Comprend également divers fixs / refactoring / ajustements