### PR TITLE
NEWFIX : Permettre d'afficher les demandes à valider dans le planning

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -193,6 +193,15 @@ function showParameters(&$form, &$doliform) {
 			print '</td>';
 			print '</tr>';
 		}
+
+        print '<tr>';
+        print '<td>';
+        print $langs->trans('PLANNING_DISPLAY_DRAFT_ABSENCE');
+        print '</td>';
+        print '<td>';
+        print ajax_constantonoff('PLANNING_DISPLAY_DRAFT_ABSENCE');
+        print '</td>';
+        print '</tr>';
 		
 		print '<tr>';
 		print '<td>';

--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -2867,7 +2867,7 @@ END:VCALENDAR
 			, 'statut' => 1
 			, 'etat' => array('Validee')
 		);
-		
+		if(!empty($conf->global->PLANNING_DISPLAY_DRAFT_ABSENCE)) $params['etat'][] = 'Avalider';
 		if (!empty($extra_params)) $params = array_merge($params, $extra_params);
 
 		if (!empty($conf->global->ABSENCE_FILTER_ON_LDAP_ENTITY_LOGIN)) $params['extrafields']['ue.ldap_entity_login'] = $conf->entity;

--- a/langs/fr_FR/absence.lang
+++ b/langs/fr_FR/absence.lang
@@ -566,3 +566,4 @@ RH_N_LABEL=Titre colonne année N
 ViewCompteurAllData=Voir toutes les données d'un compteur
 
 ABSENCE_TICKETSRESTO_COUNT_ABSENCE_AVALIDER=Tickets restaurant : prendre en compte les absences "A valider"
+PLANNING_DISPLAY_DRAFT_ABSENCE = Permettre de voir sur la vue planning les absences "à valider"


### PR DESCRIPTION
Avant absence affichait aussi les demandes à valider dans le planning, apparemment le comportement à changé, je donne la possibilité de restaurer l'ancien comportement grâce à cette conf