### PR TITLE
NEW only validable

### DIFF
--- a/lib/absence.lib.php
+++ b/lib/absence.lib.php
@@ -802,7 +802,7 @@ function _getSQLListValidation($userid)
 		dol_include_once('/valideur/class/valideur.class.php');
 	}
 	
-	return TRH_valideur_groupe::getSqlListObject('Conges');
+	return TRH_valideur_groupe::getSqlListObject('Conges', array('onlyValidable' => true));
 }
 
 /**


### PR DESCRIPTION
Sur la vue Abs à valider, si on avait le droit de voir toutes les absences, on pouvait voir les absences qu'on ne pouvait pas valider. Puisque cette permission permet de voir la liste de toutes les absences, pour retrouver cette ancienne vue, il suffit de filtrer sur l'état à valider.
Modification de cette vue pour être plus cohérent et ne voir que les absences à valider associé.

Pr associé : https://github.com/ATM-Consulting/dolibarr_module_valideur/pull/22