### PR TITLE
New valideur send mail

### DIFF
--- a/absence.php
+++ b/absence.php
@@ -94,20 +94,20 @@
 				_ficheCommentaire($PDOdb, $absence,'edit');
 				break;
 
-			case 'niveausuperieur':
-				$absence->load($PDOdb, $_REQUEST['id']);
-				$sqlEtat="UPDATE `".MAIN_DB_PREFIX."rh_absence`
-					SET niveauValidation=niveauValidation+1 WHERE rowid=".$absence->getId();
-				$PDOdb->Execute($sqlEtat);
-				$absence->load($PDOdb, $_REQUEST['id']);
-				mailConges($absence);
-				mailCongesValideur($PDOdb,$absence);
-
-				$mesg = $langs->trans('AbsenceRequestSentToSuperior');
-				setEventMessage($mesg);
-
-				_fiche($PDOdb, $absence,'view');
-				break;
+//			case 'niveausuperieur':
+//				$absence->load($PDOdb, $_REQUEST['id']);
+//				$sqlEtat="UPDATE `".MAIN_DB_PREFIX."rh_absence`
+//					SET niveauValidation=niveauValidation+1 WHERE rowid=".$absence->getId();
+//				$PDOdb->Execute($sqlEtat);
+//				$absence->load($PDOdb, $_REQUEST['id']);
+//				mailConges($absence);
+//				mailCongesValideur($PDOdb,$absence);
+//
+//				$mesg = $langs->trans('AbsenceRequestSentToSuperior');
+//				setEventMessage($mesg);
+//
+//				_fiche($PDOdb, $absence,'view');
+//				break;
 
 			case 'refuse':
 				$absence->load($PDOdb, $_REQUEST['id']);

--- a/absence.php
+++ b/absence.php
@@ -917,7 +917,7 @@ function _fiche(&$PDOdb, &$absence, $mode) {
 				,'documents'=>$input_doc
 
 				,'fk_user_absence'=>$form->hidden('fk_user_absence', $absence->fk_user)
-				,'niveauValidation'=>$absence->niveauValidation
+				,'niveauValidation'=>$absence->level
 				,'commentaireValideur'=>$absence->commentaireValideur
 				,'dt_cre'=>$absence->get_dtcre()
 				,'time_validation'=>$absence->date_validation

--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -577,8 +577,9 @@ class TRH_Absence extends TObjetStd {
 			define('INC_FROM_DOLIBARR', true);
 			dol_include_once('/valideur/config.php');
 			dol_include_once('/valideur/class/valideur.class.php');
-
+            $current_level = $this->level;
 			$canValidate = TRH_valideur_groupe::checkCanValidate($this, $user, $conf->entity, 'Conges');
+			if($this->level != $current_level) mailCongesValideur($PDOdb,$this); //On a changé de niveau
 		}
 		
 		if ($canValidate > 0)

--- a/presence.php
+++ b/presence.php
@@ -125,19 +125,19 @@
 				_ficheCommentaire($ATMdb, $absence,'edit');
 				break;
 				
-			case 'niveausuperieur':
-				$absence->load($ATMdb, $_REQUEST['id']);
-				
-				$absence->niveauValidation++;
-				$absence->save($ATMdb);
-				
-				mailConges($absence, true);
-				
-				$mesg = $langs->trans('PresenceRequestSentToSuperior');
-				setEventMessage($mesg);
-				
-				_fiche($ATMdb, $absence,'view');
-				break;
+//			case 'niveausuperieur':
+//				$absence->load($ATMdb, $_REQUEST['id']);
+//
+//				$absence->niveauValidation++;
+//				$absence->save($ATMdb);
+//
+//				mailConges($absence, true);
+//
+//				$mesg = $langs->trans('PresenceRequestSentToSuperior');
+//				setEventMessage($mesg);
+//
+//				_fiche($ATMdb, $absence,'view');
+//				break;
 				
 			case 'refuse':
 				$absence->load($ATMdb, $_REQUEST['id']);

--- a/presence.php
+++ b/presence.php
@@ -681,7 +681,7 @@ function _fiche(&$ATMdb, &$absence, $mode) {
 				,'userAbsence'=>$droitsCreation==1?$form->combo('','fk_user',$TUser,$absence->fk_user):''
 				,'userAbsenceCourant'=>$droitsCreation==1?'':$form->hidden('fk_user', $user->id)
 				,'fk_user_absence'=>$form->hidden('fk_user_absence', $absence->fk_user)
-				,'niveauValidation'=>$absence->niveauValidation
+				,'niveauValidation'=>$absence->level
 				,'commentaireValideur'=>$absence->commentaireValideur
 				,'dt_cre'=>$absence->get_dtcre()
 				,'time_validation'=>$absence->date_validation

--- a/tpl/absence.tpl.php
+++ b/tpl/absence.tpl.php
@@ -153,7 +153,7 @@
 					
 						<a class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmAcceptAbsenceRequest;strconv=no]')){actionValidAbsence('accept')};">[translate.Accept;strconv=no;protect=no]</a>	
 						<span class="butActionDelete" id="action-delete"  onclick="refuseAbsence()">[translate.Refuse;strconv=no;protect=no]</span>
-						<a style='width:30%' class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]')){actionValidAbsence('sendToSuperior')};">[translate.SendToSuperiorValidator;strconv=no;protect=no]</a>	
+<!--						<a style='width:30%' class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]')){actionValidAbsence('sendToSuperior')};">[translate.SendToSuperiorValidator;strconv=no;protect=no]</a>	-->
 									
 					[onshow;block=end]
 				[onshow;block=end]

--- a/tpl/presence.tpl.php
+++ b/tpl/presence.tpl.php
@@ -85,7 +85,7 @@
 					
 						<a class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmAcceptPresenceRequest;strconv=no]')){document.location.href='?action=accept&id=[absenceCourante.id]'};">[translate.Accept;strconv=no]</a>	
 						<span class="butActionDelete" id="action-delete"  onclick="refusePresence();">[translate.Refuse;strconv=no]</span>
-						<a style='width:30%' class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]')){document.location.href='?action=niveausuperieur&id=[absenceCourante.id]&validation=ok'};">[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]</a>	
+<!--						<a style='width:30%' class="butAction" id="action-update"  onclick="if (window.confirm('[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]')){document.location.href='?action=niveausuperieur&id=[absenceCourante.id]&validation=ok'};">[translate.ConfirmSendToSuperiorAbsenceRequest;strconv=no]</a>	-->
 									
 					[onshow;block=end]
 				[onshow;block=end]


### PR DESCRIPTION
Le bouton "monter au niveau supérieur" ne servait qu'à incrémenter le niveau de validation et envoyer un mail au valideur, sachant que le code se base sur le champ level et non niveauValidation ça ne fonctionnait pas.
Nous avons donc décidés de retirer ce bouton, d'afficher le level plutot que le niveauValidation, et d'envoyer un mail au valideur superieur quand le level est incrémenté.