### PR TITLE
Fix recap abs

### DIFF
--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -2426,15 +2426,10 @@ END:VCALENDAR
 
 			$t_current = strtotime($date_debut);
 			$t_end = strtotime($date_fin);
-			
-			$extra_params = array(
-				'extrafields' => array(
-					'ue.ticketresto_ok' => 1
-				)
-				, 'ue.ldap_entity_login' => $conf->entity
-			);
 
-			$extra_params = array_merge($extra_params, $filters);
+            if (!empty($conf->global->ABSENCE_FILTER_ON_LDAP_ENTITY_LOGIN))$extra_params = array_merge(array('ue.ldap_entity_login' => $conf->entity), $filters);
+            else $extra_params = $filters;
+
 
 			$TPlanning = $abs->requetePlanningAbsence2($PDOdb, $idGroupeRecherche, $idUserRecherche, date('d/m/Y', $t_current), date('d/m/Y', $t_end), $extra_params);
 			$Tab = array(); // Tableau de retour de fonction

--- a/class/ticket.class.php
+++ b/class/ticket.class.php
@@ -161,7 +161,11 @@ class TRH_TicketResto extends TObjetStd {
 		$planningFilters = array();
 		if (! empty($conf->global->ABSENCE_TICKETSRESTO_COUNT_ABSENCE_AVALIDER))
 		{
-			$planningFilters = array('etat' => array('Avalider', 'Validee'));
+			$planningFilters = array('etat' => array('Avalider', 'Validee'),
+                                     'extrafields' => array(
+                                            'ue.ticketresto_ok' => 1
+                                        )
+                                    );
 		}
 
 		$TAbsence = TRH_Absence::getPlanning($ATMdb, $idGroup, $fk_user, $date_debut, $date_fin, $planningFilters);

--- a/lib/absence.lib.php
+++ b/lib/absence.lib.php
@@ -713,7 +713,6 @@ function _recap_abs(&$PDOdb, $idGroupeRecherche, $idUserRecherche, $date_debut, 
 
 			@$stat['presence']+=$row['nb_jour_presence'];
 			@$stat['absence']+=$row['nb_jour_absence'];
-			@$stat['absence_heure']+=$row['nb_heure_absence'];
 			@$stat['presence+ferie']+=$row['nb_jour_presence'] + $row['nb_jour_ferie'];
 			@$stat['absence+ferie']+=$row['nb_jour_absence'] + $row['nb_jour_ferie'] ;
 			@$stat['ferie']+=$row['nb_jour_ferie'] ;

--- a/lib/absence.lib.php
+++ b/lib/absence.lib.php
@@ -695,9 +695,7 @@ function _recap_abs(&$PDOdb, $idGroupeRecherche, $idUserRecherche, $date_debut, 
 	$html .= '<tr>
 				<td>' . $langs->trans('Name') . '</td>
 				<td>' . $langs->trans('PresenceDay') . '</td>
-				<td>' . $langs->trans('PresenceHour') . '</td>
 				<td>' . $langs->trans('AbsenceDay') . '</td>
-				<td>' . $langs->trans('AbsenceHour') . '</td>
 				<td>' . $langs->trans('Presence') . ' + ' . $langs->trans('PublicHolidayDay') . '</td>
 				<td>' . $langs->trans('Absence') . ' + ' . $langs->trans('PublicHolidayDay') . '</td>
 				<td>' . $langs->trans('PublicHolidayDay') . '</td>
@@ -714,7 +712,6 @@ function _recap_abs(&$PDOdb, $idGroupeRecherche, $idUserRecherche, $date_debut, 
 		foreach($TStat as $date=>$row) {
 
 			@$stat['presence']+=$row['nb_jour_presence'];
-			@$stat['presence_heure']+=$row['nb_heure_presence'];
 			@$stat['absence']+=$row['nb_jour_absence'];
 			@$stat['absence_heure']+=$row['nb_heure_absence'];
 			@$stat['presence+ferie']+=$row['nb_jour_presence'] + $row['nb_jour_ferie'];
@@ -727,9 +724,7 @@ function _recap_abs(&$PDOdb, $idGroupeRecherche, $idUserRecherche, $date_debut, 
 		$html .= '<tr><td style="text-align:left;">'.$u->getNomUrl().'</td>';
 		
 		$html .= '<td>'.$stat['presence'].'</td>';
-		$html .= '<td>'.$stat['presence_heure'].'</td>';
 		$html .= '<td>'.$stat['absence'].'</td>';
-		$html .= '<td>'.$stat['absence_heure'].'</td>';
 		$html .= '<td>'.$stat['presence+ferie'].'</td>';
 		$html .= '<td>'.$stat['absence+ferie'].'</td>';
 		$html .= '<td>'.$stat['ferie'].'</td></tr>';


### PR DESCRIPTION
Le paramètre ticket resto est forcé actuellement, ce qui errone les données si les utilisateurs n'utilisent pas les tickets resto, de plus la gestion des absences + presence en heure est commenté aujourd'hui donc non fonctionnel, aucun interet à afficher ces colonnes