### PR TITLE
FIX detail compteur

### DIFF
--- a/class/absence.class.php
+++ b/class/absence.class.php
@@ -526,7 +526,7 @@ class TRH_Absence extends TObjetStd {
         $TAbs =TRH_Absence::getPlanning($PDOdb,0, $fk_user, $date_start, $date_end);
 	    $totalConges = 0;
         foreach($TAbs[$fk_user] as $dt => $abs) {
-            if(! empty($abs['absence']) && $abs['estUnJourTravaille']) {
+            if(! empty($abs['absence']) && $abs['estUnJourTravaille'] === 'OUI') {
                 if(count($abs['typeAbsence']) > 1) {
                     foreach($abs['typeAbsence'] as $typeAbs) {
                         if(in_array($typeAbs->typeAbs, TRH_Absence::$TAbsenceTypeDecompteConges)) $totalConges+=0.5;

--- a/compteur.php
+++ b/compteur.php
@@ -298,8 +298,8 @@ function _fiche(&$PDOdb, &$compteur, $mode) {
     $dateEndPoseNM1 = date('Y-m-d', $compteur->date_congesCloture);
     $dateStartPrisNM1 = date('Y-m-d', strtotime('-1 year +1 day',$compteur->date_congesCloture));
     $dateEndPrisNM1 = date('Y-m-d');
-    $totalCongesPoseNM1 = TRH_Absence::getUserPeriodTotalConges($PDOdb, $user->id, $dateStartPoseNM1, $dateEndPoseNM1);
     $totalCongesPrisNM1 = TRH_Absence::getUserPeriodTotalConges($PDOdb, $user->id, $dateStartPrisNM1, $dateEndPrisNM1);
+    $totalCongesPoseNM1 = TRH_Absence::getUserPeriodTotalConges($PDOdb, $user->id, $dateStartPoseNM1, $dateEndPoseNM1);
 
     $morehtmlref.='<div class="refidno">';
     $morehtmlref.= $langs->trans('HolidaysTaken').' : <strong>'.round2Virgule($compteur->congesPrisNM1).'</strong> &nbsp;&nbsp;&nbsp;';
@@ -452,8 +452,8 @@ function _fiche(&$PDOdb, &$compteur, $mode) {
 				'acquisRecuperation'=>$langs->transnoentities('acquisRecuperation'),
 				'AbsenceNM1'=>$langs->transnoentities('AbsenceNM1'),
 				'AbsenceN'=>$langs->transnoentities('AbsenceN'),
-				'totalHolidaysTakenNM1Past'=>$formStd->textwithpicto($langs->transnoentities('totalHolidaysTakenNM1Future'),$langs->transnoentities('pictoTotalCongesPoseNM1', date('d/m/Y',strtotime($dateStartPoseNM1)), date('d/m/Y',strtotime($dateEndPoseNM1)))),
-				'totalHolidaysTakenNM1Future'=>$formStd->textwithpicto($langs->transnoentities('totalHolidaysTakenNM1Past'),$langs->transnoentities('pictoTotalCongesPrisNM1', date('d/m/Y',strtotime($dateStartPrisNM1)), date('d/m/Y',strtotime($dateEndPrisNM1)))),
+				'totalHolidaysTakenNM1Future'=>$formStd->textwithpicto($langs->transnoentities('totalHolidaysTakenNM1Future'),$langs->transnoentities('pictoTotalCongesPoseNM1', date('d/m/Y',strtotime($dateStartPoseNM1)), date('d/m/Y',strtotime($dateEndPoseNM1)))),
+				'totalHolidaysTakenNM1Past'=>$formStd->textwithpicto($langs->transnoentities('totalHolidaysTakenNM1Past'),$langs->transnoentities('pictoTotalCongesPrisNM1', date('d/m/Y',strtotime($dateStartPrisNM1)), date('d/m/Y',strtotime($dateEndPrisNM1)))),
 				'langs'=>$langs
 			)
 		)	

--- a/tpl/compteur.tpl.php
+++ b/tpl/compteur.tpl.php
@@ -35,13 +35,14 @@
 					<td><b>[translate.TotalHolidays;strconv=no;protect=no]</b></td>
 					<td><b>[congesPrec.total;strconv=no;protect=no] </b></td>
 				</tr>
-            <tr>
-                <td>[translate.totalHolidaysTakenNM1Future;strconv=no;protect=no]</td>
-                <td>[congesPrec.totalCongesPoseNM1;strconv=no;protect=no]</td>
-            </tr>
+
             <tr>
                 <td>[translate.totalHolidaysTakenNM1Past;strconv=no;protect=no]</td>
                 <td>[congesPrec.totalCongesPrisNM1;strconv=no;protect=no]</td>
+            </tr>
+            <tr>
+                <td>[translate.totalHolidaysTakenNM1Future;strconv=no;protect=no]</td>
+                <td>[congesPrec.totalCongesPoseNM1;strconv=no;protect=no]</td>
             </tr>
 				<tr>
 					<td><b>[translate.HolidaysTaken;strconv=no;protect=no]</b></td>


### PR DESCRIPTION
FIX pour

>  Les compteurs de congés pris / posés ne fonctionnent pas correctement. Si je pose un congés aujourd'hui dans le passé, il apparait dans les congés posés alors qu'il devrait apparaitre dans les congés pris. Attention, la somme des compteurs pris / posés n'est pas égale au détail si on pose des absences incluant des weekends !!