### PR TITLE
Fix/ergonomie make conf rh ndf ticket resto easier

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -89,7 +89,6 @@ function showParameters(&$form, &$doliform) {
 		,'RH_JOURS_NON_TRAVAILLE'
 		,'RH_MONTANT_TICKET_RESTO'
 		,'RH_PART_PATRON_TICKET_RESTO'
-		,'RH_NDF_TICKET_RESTO'
 		,'RH_CODEPRODUIT_TICKET_RESTO'
 		,'RH_CODECLIENT_TICKET_RESTO'
 		,'TIMESHEET_WORKING_HOUR_PER_DAY'
@@ -113,6 +112,29 @@ function showParameters(&$form, &$doliform) {
 		</tr><?php
 
 		}
+
+		// on récupère les ID, les codes et les labels du dictionnaire des types de dépenses de NDF de l’entité
+		$resql = $db->query(
+			'SELECT rowid, code, label FROM ' . MAIN_DB_PREFIX . 'c_exp'
+			. ' WHERE active = 1 AND entity IN (' . getEntity('') . ')'
+		);
+		if ($resql) {
+			$TExpenseTypeOption = array('<option value="">–</option>');
+			while ($obj = $db->fetch_object($resql)) {
+				$selected = $obj->rowid == $conf->global->RH_NDF_TICKET_RESTO ? ' selected ' : '';
+				$TExpenseTypeOption[] = '<option value="'. $obj->rowid .'" ' . $selected . '>'. $obj->code . ' - ' . $langs->trans($obj->label) .'</option>';
+			}
+			echo '<tr>'
+				 . '<td>' . $langs->trans('RH_NDF_TICKET_RESTO') . '</td>'
+				 . '<td><select id="RH_NDF_TICKET_RESTO" name="TConst[RH_NDF_TICKET_RESTO]">'
+				 . implode('', $TExpenseTypeOption)
+				 . '</select>'
+				 . '</td>'
+				 . '</tr>';
+		} else {
+			setEventMessages('', array('<pre>' . $db->lastquery() . '</pre>', $db->lasterror()), 'errors');
+		}
+
 		print '<tr>';
 		print '<td>';
 		print $langs->trans('absenceTicketRestoOnUserCreate');

--- a/core/modules/modAbsence.class.php
+++ b/core/modules/modAbsence.class.php
@@ -59,7 +59,7 @@ class modAbsence extends DolibarrModules
 		// Module description, used if translation string 'ModuleXXXDesc' not found (where XXX is value of numeric property 'numero' of module)
 		$this->description = $langs->trans('ModuleAbsenceDesc');
 		// Possible values for version are: 'development', 'experimental', 'dolibarr' or version
-		$this->version = '1.3.5';
+		$this->version = '1.3.6';
 		// Key used in llx_const table to save module status enabled/disabled (where MYMODULE is value of property name of module in uppercase)
 		$this->const_name = 'MAIN_MODULE_'.strtoupper($this->name);
 		// Where to store the module in setup page (0=common,1=interface,2=others,3=very specific)


### PR DESCRIPTION
# FIX ergonomie

Actuellement, la conf _Id. de repas salariés dans le module note de frais_ est un input de type "texte", ce qui n’est pas pratique (ça oblige à aller chercher l’ID dans le dictionnaire des types de dépenses pour chaque entité). Ce fix d’ergonomie remplace cet input par un `<select>`.